### PR TITLE
feat: mini 스타일 추가

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,33 +1,44 @@
-const express = require('express');
+const express = require("express");
 const app = express();
-const cofo = require('./utils/cofo');
-const sql = require('./utils/sql');
-const { svgDataForLGM, svgDataForGeneralRating } = require('./utils/SVGs');
+const cofo = require("./utils/cofo");
+const sql = require("./utils/sql");
+const {
+  svgDataForLGM,
+  svgDataForGeneralRating,
+  svgDataMini,
+} = require("./utils/SVGs");
 
-app.use('/', async (req, res) => {
-  res.setHeader('Content-Type', 'image/svg+xml');
-  res.setHeader('Cache-Control', 'public, max-age=3600');
+app.use("/", async (req, res) => {
+  res.setHeader("Content-Type", "image/svg+xml");
+  res.setHeader("Cache-Control", "public, max-age=3600");
 
   // handle errors
   const id = req.query.id;
-  if (!id) return res.send('<svg>handle cannot be empty</svg>');
-  const handleFormat = id.replace(/[a-zA-Z0-9-_]/g, '')
-  if (handleFormat) return res.send('<svg>handle should only contain Latin letters, digits, underscore or dash characters</svg>');
+  const mini = req.query.mini;
+
+  if (!id) return res.send("<svg>handle cannot be empty</svg>");
+  const handleFormat = id.replace(/[a-zA-Z0-9-_]/g, "");
+  if (handleFormat)
+    return res.send(
+      "<svg>handle should only contain Latin letters, digits, underscore or dash characters</svg>"
+    );
 
   // get user rank, rating
-  const { status, userInfo } = await getUserInfo(id)
-  if (status === "FAILED") return res.send('<svg>handle not available</svg>')
+  const { status, userInfo } = await getUserInfo(id);
+  if (status === "FAILED") return res.send("<svg>handle not available</svg>");
 
   // handle errors
   if (!userInfo.rank) {
-    return res.send('<svg>rating not available</svg>');
+    return res.send("<svg>rating not available</svg>");
   }
 
   // render svg
-  if (userInfo.rank === "legendary grandmaster") {
-    res.send(svgDataForLGM(userInfo))
-  } else
-    res.send(svgDataForGeneralRating(userInfo))
+  console.log(mini);
+  if (mini) {
+    res.send(svgDataMini(userInfo));
+  } else if (userInfo.rank === "legendary grandmaster") {
+    res.send(svgDataForLGM(userInfo));
+  } else res.send(svgDataForGeneralRating(userInfo));
 });
 
 const getUserInfo = async (id) => {
@@ -36,17 +47,17 @@ const getUserInfo = async (id) => {
     rank: "",
     rating: "",
     maxRank: "",
-    maxRating: ""
+    maxRating: "",
   };
 
-  const { exists, rows } = await sql.getClient(id)
+  const { exists, rows } = await sql.getClient(id);
   if (!exists) {
-    const { status, result } = await cofo.getTier(id)
+    const { status, result } = await cofo.getTier(id);
     // not available handle in codeforces
-    if (status === "FAILED") return { status, userInfo }
+    if (status === "FAILED") return { status, userInfo };
 
     // insert newly added handle data
-    await sql.insertData(result[0])
+    await sql.insertData(result[0]);
     userInfo.id = id;
     userInfo.rank = result[0].rank;
     userInfo.rating = result[0].rating;
@@ -60,9 +71,9 @@ const getUserInfo = async (id) => {
     userInfo.maxRank = rows[0].maxRank;
     userInfo.maxRating = rows[0].topRating;
   }
-  return { status: "SUCCESS", userInfo }
-}
+  return { status: "SUCCESS", userInfo };
+};
 
 const server = app.listen(2021, () => {
-  console.log('server has started on 2021');
-})
+  console.log("server has started on 2021");
+});

--- a/utils/SVGs.js
+++ b/utils/SVGs.js
@@ -1,8 +1,8 @@
-const SVGs = module.exports = {};
-const { RANK_EXP, TIER_COLOR } = require('./cofoRatingInfo')
+const SVGs = (module.exports = {});
+const { RANK_EXP, TIER_COLOR, MINI_COLOR } = require("./cofoRatingInfo");
 
 SVGs.svgDataForLGM = (userInfo) => {
-    const str = `
+  const str = `
   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="350" height="131" viewBox="0 0 350 131">
   <defs>
   <clipPath id="clip-맞춤형_크기_39">
@@ -14,26 +14,61 @@ SVGs.svgDataForLGM = (userInfo) => {
   <path d="M20,0H324a20,20,0,0,1,20,20v81a20,20,0,0,1-20,20H20A20,20,0,0,1,0,101V20A20,20,0,0,1,20,0Z" stroke="none"/>
   <path d="M 20 0.5 C 17.3673095703125 0.5 14.81362915039063 1.0155029296875 12.40985107421875 2.032180786132813 C 10.08792114257813 3.014320373535156 8.002410888671875 4.42041015625 6.211395263671875 6.211410522460938 C 4.42041015625 8.002410888671875 3.014312744140625 10.08790588378906 2.032196044921875 12.40986633300781 C 1.0155029296875 14.81363677978516 0.5 17.36731719970703 0.5 20 L 0.5 101 C 0.5 103.632682800293 1.0155029296875 106.1863632202148 2.032196044921875 108.5901336669922 C 3.014312744140625 110.9120941162109 4.42041015625 112.9975891113281 6.211395263671875 114.7885894775391 C 8.002410888671875 116.57958984375 10.08792114257813 117.9856796264648 12.40985107421875 118.9678192138672 C 14.81362915039063 119.9844970703125 17.3673095703125 120.5 20 120.5 L 324 120.5 C 326.6326904296875 120.5 329.1863708496094 119.9844970703125 331.5901489257813 118.9678192138672 C 333.9120788574219 117.9856796264648 335.9975891113281 116.57958984375 337.7886047363281 114.7885894775391 C 339.57958984375 112.9975891113281 340.9856872558594 110.9120941162109 341.9678039550781 108.5901336669922 C 342.9844970703125 106.1863632202148 343.5 103.632682800293 343.5 101 L 343.5 20 C 343.5 17.36731719970703 342.9844970703125 14.81363677978516 341.9678039550781 12.40986633300781 C 340.9856872558594 10.08790588378906 339.57958984375 8.002410888671875 337.7886047363281 6.211410522460938 C 335.9975891113281 4.42041015625 333.9120788574219 3.014320373535156 331.5901489257813 2.032180786132813 C 329.1863708496094 1.0155029296875 326.6326904296875 0.5 324 0.5 L 20 0.5 M 20 0 L 324 0 C 335.0456848144531 0 344 8.954315185546875 344 20 L 344 101 C 344 112.0456848144531 335.0456848144531 121 324 121 L 20 121 C 8.954315185546875 121 0 112.0456848144531 0 101 L 0 20 C 0 8.954315185546875 8.954315185546875 0 20 0 Z" stroke="none" fill="#aaa"/>
   <g id="name_bar" data-name="name &amp; bar" transform="translate(0 15)">
-  <text id="USER_ID" transform="translate(330 15)" fill="${TIER_COLOR[userInfo.rank]}" font-size="1.8em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700" text-anchor="end"><tspan x="0" y="28"><tspan fill="#000000">${userInfo.id[0]}</tspan><tspan fill="#FC1212">${userInfo.id.substring(1)}</tspan></tspan></text>
-  <text id="USER_RANK" transform="translate(18 15)" fill="${TIER_COLOR[userInfo.rank]}" font-size="1em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="0" fill="#000000">L</tspan><tspan fill="#FC1212">egendary Grandmaster</tspan></text>
+  <text id="USER_ID" transform="translate(330 15)" fill="${
+    TIER_COLOR[userInfo.rank]
+  }" font-size="1.8em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700" text-anchor="end"><tspan x="0" y="28"><tspan fill="#000000">${
+    userInfo.id[0]
+  }</tspan><tspan fill="#FC1212">${userInfo.id.substring(
+    1
+  )}</tspan></tspan></text>
+  <text id="USER_RANK" transform="translate(18 15)" fill="${
+    TIER_COLOR[userInfo.rank]
+  }" font-size="1em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="0" fill="#000000">L</tspan><tspan fill="#FC1212">egendary Grandmaster</tspan></text>
   <rect id="EXP_BAR" width="315" height="6" transform="translate(18 56)" fill="#000000"/>
-  <rect id="CUR_EXP_BAR" width="${(userInfo.rating - RANK_EXP[userInfo.rank]['min']) / (RANK_EXP[userInfo.rank]['max'] - RANK_EXP[userInfo.rank]['min']) * 315}" height="6" transform="translate(18 56)" fill="${TIER_COLOR[userInfo.rank]}"/>
-  <text id="CUR_EXP" transform="translate(${(userInfo.rating - RANK_EXP[userInfo.rank]['min']) / (RANK_EXP[userInfo.rank]['max'] - RANK_EXP[userInfo.rank]['min']) * 315 + 16} 73)" fill="${TIER_COLOR[userInfo.rank]}" font-size="0.75em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="-12" y="0">${userInfo.rating}</tspan></text>
+  <rect id="CUR_EXP_BAR" width="${
+    ((userInfo.rating - RANK_EXP[userInfo.rank]["min"]) /
+      (RANK_EXP[userInfo.rank]["max"] - RANK_EXP[userInfo.rank]["min"])) *
+    315
+  }" height="6" transform="translate(18 56)" fill="${
+    TIER_COLOR[userInfo.rank]
+  }"/>
+  <text id="CUR_EXP" transform="translate(${
+    ((userInfo.rating - RANK_EXP[userInfo.rank]["min"]) /
+      (RANK_EXP[userInfo.rank]["max"] - RANK_EXP[userInfo.rank]["min"])) *
+      315 +
+    16
+  } 73)" fill="${
+    TIER_COLOR[userInfo.rank]
+  }" font-size="0.75em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="-12" y="0">${
+    userInfo.rating
+  }</tspan></text>
   </g>
   <g id="max" transform="translate(-8 -18.573)">
   <text id="top_rating" transform="translate(26 132.573)" fill="#000000" font-size="0.78em" font-family="SegoeUI-Semibold, Segoe UI, system-ui, -apple-system" font-weight="600"><tspan x="0" y="0">top rating</tspan></text>
   <text id="max_rank" transform="translate(26 118.573)" fill="#000000" font-size="0.78em" font-family="SegoeUI-Semibold, Segoe UI, system-ui, -apple-system" font-weight="600"><tspan x="0" y="0">max rank</tspan></text>
-  ${userInfo.maxRank.length === 21 ? `<text id="cur_mak_rank" transform="translate(100 105.573)" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="13" fill="#000">L</tspan><tspan y="13" fill="#FF0000">egendary Grandmaster</tspan></text>` : `<text id="cur_mak_rank" transform="translate(100 105.573)" fill="${TIER_COLOR[userInfo.maxRank]}" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan y="13">${RANK_EXP[userInfo.maxRank]['displayName']}</tspan></text>`}
-  <text id="cur_top_rating" transform="translate(100 120.573)" fill="${TIER_COLOR[userInfo.maxRank]}" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="13">${userInfo.maxRating}</tspan></text>
+  ${
+    userInfo.maxRank.length === 21
+      ? `<text id="cur_mak_rank" transform="translate(100 105.573)" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="13" fill="#000">L</tspan><tspan y="13" fill="#FF0000">egendary Grandmaster</tspan></text>`
+      : `<text id="cur_mak_rank" transform="translate(100 105.573)" fill="${
+          TIER_COLOR[userInfo.maxRank]
+        }" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan y="13">${
+          RANK_EXP[userInfo.maxRank]["displayName"]
+        }</tspan></text>`
+  }
+  <text id="cur_top_rating" transform="translate(100 120.573)" fill="${
+    TIER_COLOR[userInfo.maxRank]
+  }" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="13">${
+    userInfo.maxRating
+  }</tspan></text>
   </g>
   </g>
   </g>
   </svg>
-  `
-    return str
-  }
+  `;
+  return str;
+};
 SVGs.svgDataForGeneralRating = (userInfo) => {
-    const str = `
+  const str = `
     <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="350" height="131" viewBox="0 0 350 131">
   <defs>
   <clipPath id="clip-맞춤형_크기_39">
@@ -43,22 +78,120 @@ SVGs.svgDataForGeneralRating = (userInfo) => {
   <g id="맞춤형_크기_39" data-name="맞춤형 크기 – 39" clip-path="url(#clip-맞춤형_크기_39)">
   <rect id="CONTAINER" width="344" height="121" rx="20" transform="translate(3 5)" fill="#36393f"/>
   <g id="name_bar" data-name="name &amp; bar" transform="translate(0 15)">
-  <text id="USER_ID" transform="translate(330 15)" fill="${TIER_COLOR[userInfo.rank]}" font-size="1.8em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700" text-anchor="end"><tspan x="0" y="28">${userInfo.id}</tspan></text>
-  <text id="USER_RANK" transform="translate(18 15)" fill="${TIER_COLOR[userInfo.rank]}" font-size="1em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="0">${RANK_EXP[userInfo.rank]['displayName']}</tspan></text>
+  <text id="USER_ID" transform="translate(330 15)" fill="${
+    TIER_COLOR[userInfo.rank]
+  }" font-size="1.8em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700" text-anchor="end"><tspan x="0" y="28">${
+    userInfo.id
+  }</tspan></text>
+  <text id="USER_RANK" transform="translate(18 15)" fill="${
+    TIER_COLOR[userInfo.rank]
+  }" font-size="1em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="0">${
+    RANK_EXP[userInfo.rank]["displayName"]
+  }</tspan></text>
   <rect id="EXP_BAR" width="315" height="6" transform="translate(18 56)" fill="#707070"/>
-  <rect id="CUR_EXP_BAR" width="${(userInfo.rating - RANK_EXP[userInfo.rank]['min']) / (RANK_EXP[userInfo.rank]['max'] - RANK_EXP[userInfo.rank]['min']) * 315}" height="6" transform="translate(18 56)" fill="${TIER_COLOR[userInfo.rank]}"/>
-  <text id="CUR_EXP" transform="translate(${(userInfo.rating - RANK_EXP[userInfo.rank]['min']) / (RANK_EXP[userInfo.rank]['max'] - RANK_EXP[userInfo.rank]['min']) * 315 + 16} 73)" fill="${TIER_COLOR[userInfo.rank]}" font-size="0.75em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="-12" y="0">${userInfo.rating}</tspan></text>
-  <text id="MAX_EXP" transform="translate(306 73)" fill="${TIER_COLOR[userInfo.rank]}" font-size="0.75em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="0">${(userInfo.rating - RANK_EXP[userInfo.rank]['min']) / (RANK_EXP[userInfo.rank]['max'] - RANK_EXP[userInfo.rank]['min']) * 315 + 16 >= 288 ? '' : RANK_EXP[userInfo.rank]['max']}</tspan></text>
+  <rect id="CUR_EXP_BAR" width="${
+    ((userInfo.rating - RANK_EXP[userInfo.rank]["min"]) /
+      (RANK_EXP[userInfo.rank]["max"] - RANK_EXP[userInfo.rank]["min"])) *
+    315
+  }" height="6" transform="translate(18 56)" fill="${
+    TIER_COLOR[userInfo.rank]
+  }"/>
+  <text id="CUR_EXP" transform="translate(${
+    ((userInfo.rating - RANK_EXP[userInfo.rank]["min"]) /
+      (RANK_EXP[userInfo.rank]["max"] - RANK_EXP[userInfo.rank]["min"])) *
+      315 +
+    16
+  } 73)" fill="${
+    TIER_COLOR[userInfo.rank]
+  }" font-size="0.75em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="-12" y="0">${
+    userInfo.rating
+  }</tspan></text>
+  <text id="MAX_EXP" transform="translate(306 73)" fill="${
+    TIER_COLOR[userInfo.rank]
+  }" font-size="0.75em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="0">${
+    ((userInfo.rating - RANK_EXP[userInfo.rank]["min"]) /
+      (RANK_EXP[userInfo.rank]["max"] - RANK_EXP[userInfo.rank]["min"])) *
+      315 +
+      16 >=
+    288
+      ? ""
+      : RANK_EXP[userInfo.rank]["max"]
+  }</tspan></text>
   </g>
   <g id="max" transform="translate(-8 -18.573)">
   <text id="top_rating" transform="translate(26 132.573)" fill="#fff" font-size="0.78em" font-family="SegoeUI-Semibold, Segoe UI, system-ui, -apple-system" font-weight="600"><tspan x="0" y="0">top rating</tspan></text>
   <text id="max_rank" transform="translate(26 118.573)" fill="#fff" font-size="0.78em" font-family="SegoeUI-Semibold, Segoe UI, system-ui, -apple-system" font-weight="600"><tspan x="0" y="0">max rank</tspan></text>
-  ${userInfo.maxRank.length === 21 ? `<text id="cur_mak_rank" transform="translate(100 105.573)" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="13" fill="#000">L</tspan><tspan y="13" fill="#FF0000">egendary Grandmaster</tspan></text>` : `<text id="cur_mak_rank" transform="translate(100 105.573)" fill="${TIER_COLOR[userInfo.maxRank]}" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan y="13">${RANK_EXP[userInfo.maxRank]['displayName']}</tspan></text>`}
-  <text id="cur_top_rating" transform="translate(100 120.573)" fill="${TIER_COLOR[userInfo.maxRank]}" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="13">${userInfo.maxRating}</tspan></text>
+  ${
+    userInfo.maxRank.length === 21
+      ? `<text id="cur_mak_rank" transform="translate(100 105.573)" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="13" fill="#000">L</tspan><tspan y="13" fill="#FF0000">egendary Grandmaster</tspan></text>`
+      : `<text id="cur_mak_rank" transform="translate(100 105.573)" fill="${
+          TIER_COLOR[userInfo.maxRank]
+        }" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan y="13">${
+          RANK_EXP[userInfo.maxRank]["displayName"]
+        }</tspan></text>`
+  }
+  <text id="cur_top_rating" transform="translate(100 120.573)" fill="${
+    TIER_COLOR[userInfo.maxRank]
+  }" font-size="0.78em" font-family="SegoeUI-Bold, Segoe UI, system-ui, -apple-system" font-weight="700"><tspan x="0" y="13">${
+    userInfo.maxRating
+  }</tspan></text>
   </g>
   </g>
   </svg>
   
-    `
-    return str
-  }
+    `;
+  return str;
+};
+
+SVGs.svgDataMini = (userInfo) => {
+  const rank = userInfo.rank;
+  const rating = userInfo.rating;
+  const color = MINI_COLOR[rank];
+  return `<!DOCTYPE svg PUBLIC
+    "-//W3C//DTD SVG 1.1//EN"
+    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg height="20" width="110"
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xml:space="preserve">
+  <style type="text/css">
+    <![CDATA[
+      @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=block');
+      @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap');
+      .background {
+        fill: url(#grad1);
+      }
+      text {
+        fill: white;
+        font-family: 'Noto Sans KR', sans-serif;
+        font-size: 0.7em;
+      }
+      .gray-area {
+        fill: #555555;
+      }
+      .tier {
+        fill: ${rank == "legendary grandmaster" ? "black" : "white"};
+        font-weight: 700;
+        font-size: 0.7em;
+      }
+    ]]>
+  </style>
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="35%">
+      <stop offset="20%" style="stop-color:${[color[0]]};stop-opacity:1" />
+      <stop offset="55%" style="stop-color:${color[1]};stop-opacity:1" />
+      <stop offset="100%" style="stop-color:${color[2]};stop-opacity:1" />
+    </linearGradient>
+    <clipPath id="round-corner">
+      <rect x="0" y="0" width="110" height="20" rx="3" ry="3"/>
+    </clipPath>
+  </defs>
+  <rect width="40" height="20" x="70" y="0" rx="3" ry="3" class="background"/>
+  <rect width="75" height="20" clip-path="url(#round-corner)" class="gray-area"/>
+  <text text-anchor="middle" alignment-baseline="middle" transform="translate(37.5, 11)">codeforces</text>
+  <text class="tier" text-anchor="middle" alignment-baseline="middle" transform="translate(92, 11)">
+  ${rating}
+  </text>
+</svg>`;
+};

--- a/utils/cofoRatingInfo.js
+++ b/utils/cofoRatingInfo.js
@@ -1,66 +1,89 @@
-const cofoRatingInfo = module.exports = {};
+const cofoRatingInfo = (module.exports = {});
 cofoRatingInfo.TIER_COLOR = {
-    newbie: "#CBCBCB",
-    pupil: "#32D336",
-    specialist: "#00D9CC",
-    expert: "#656AFF",
-    'candidate master': "#EE00EE",
-    master: "#FF8C00",
-    'international master': "#FF8C00",
-    grandmaster: "#FC1212",
-    'international grandmaster': "#FC1212",
-    'legendary grandmaster': "#FC1212"
+  newbie: "#CBCBCB",
+  pupil: "#32D336",
+  specialist: "#00D9CC",
+  expert: "#656AFF",
+  "candidate master": "#EE00EE",
+  master: "#FF8C00",
+  "international master": "#FF8C00",
+  grandmaster: "#FC1212",
+  "international grandmaster": "#FC1212",
+  "legendary grandmaster": "#FC1212",
+};
+
+const COLOR_CODE = {
+  GRAY: ["#968A87", "#808080", "#96878F"],
+  GREEN: ["#089630", "#008000", "#399608"],
+  MINT: ["#069ABF", "#03A89E", "#06BF7E"],
+  BLUE: ["#480CE8", "#0000FF", "#0C46E8"],
+  PURPLE: ["#C20A66", "#AA00AA", "#900AC2"],
+  ORANGE: ["#E89D0C", "#FF8C00", "#E8650C"],
+  RED: ["#E82C0C", "#FF0000", "#E80C7A"],
+};
+
+cofoRatingInfo.MINI_COLOR = {
+  newbie: COLOR_CODE.GRAY,
+  pupil: COLOR_CODE.GREEN,
+  specialist: COLOR_CODE.MINT,
+  expert: COLOR_CODE.BLUE,
+  "candidate master": COLOR_CODE.PURPLE,
+  master: COLOR_CODE.ORANGE,
+  "international master": COLOR_CODE.ORANGE,
+  grandmaster: COLOR_CODE.RED,
+  "international grandmaster": COLOR_CODE.RED,
+  "legendary grandmaster": COLOR_CODE.RED,
 };
 
 cofoRatingInfo.RANK_EXP = {
-    newbie: {
-        displayName: "Newbie",
-        min: 0,
-        max: 1199
-    },
-    pupil: {
-        displayName: "Pupil",
-        min: 1200,
-        max: 1399
-    },
-    specialist: {
-        displayName: "Specialist",
-        min: 1400,
-        max: 1599
-    },
-    expert: {
-        displayName: "Expert",
-        min: 1600,
-        max: 1899
-    },
-    'candidate master': {
-        displayName: "Candidate Master",
-        min: 1900,
-        max: 2099
-    },
-    master: {
-        displayName: "Master",
-        min: 2100,
-        max: 2299
-    },
-    'international master': {
-        displayName: "International Master",
-        min: 2300,
-        max: 2399
-    },
-    grandmaster: {
-        displayName: "Grandmaster",
-        min: 2400,
-        max: 2599
-    },
-    'international grandmaster': {
-        displayName: "International Grandmaster",
-        min: 2600,
-        max: 2999
-    },
-    'legendary grandmaster': {
-        displayName: "Legendary Grandmaster",
-        min: 3000,
-        max: 5000
-    }
+  newbie: {
+    displayName: "Newbie",
+    min: 0,
+    max: 1199,
+  },
+  pupil: {
+    displayName: "Pupil",
+    min: 1200,
+    max: 1399,
+  },
+  specialist: {
+    displayName: "Specialist",
+    min: 1400,
+    max: 1599,
+  },
+  expert: {
+    displayName: "Expert",
+    min: 1600,
+    max: 1899,
+  },
+  "candidate master": {
+    displayName: "Candidate Master",
+    min: 1900,
+    max: 2099,
+  },
+  master: {
+    displayName: "Master",
+    min: 2100,
+    max: 2299,
+  },
+  "international master": {
+    displayName: "International Master",
+    min: 2300,
+    max: 2399,
+  },
+  grandmaster: {
+    displayName: "Grandmaster",
+    min: 2400,
+    max: 2599,
+  },
+  "international grandmaster": {
+    displayName: "International Grandmaster",
+    min: 2600,
+    max: 2999,
+  },
+  "legendary grandmaster": {
+    displayName: "Legendary Grandmaster",
+    min: 3000,
+    max: 5000,
+  },
 };


### PR DESCRIPTION
안녕하세요! 

먼저 mazassumnida 서비스를 잘 이용하고 있고 감사의 말씀 드립니다!

백준 뱃지 mini 버전이랑 통일하고 싶어서 제작해봤는데 혹시 검토 가능할까요? 

url에 {mini=true} 쿼리를 추가해주면 해당 svg를 생성하도록 했습니다.

린터때문에 diff 가 마구 생겨버린점 죄송합니다,,, 



## 적용 사진
Gray
![image](https://user-images.githubusercontent.com/63437430/151519483-e6205d0b-8384-4e80-bbe6-c175544c7f02.png)

Green
![image](https://user-images.githubusercontent.com/63437430/151519518-3e6ec50c-bddd-4804-b8f0-050bad134b68.png)

Mint
![image](https://user-images.githubusercontent.com/63437430/151519534-fb7356a4-85e7-4a1a-bbb4-49d10ac26083.png)

Blue
![image](https://user-images.githubusercontent.com/63437430/151519556-a1b6ace5-32a9-48a7-86a1-e29e6ac94f00.png)

Purple
![image](https://user-images.githubusercontent.com/63437430/151534207-7d4a8ce5-82c6-4d07-bed7-585ef19aa43c.png)


Orange
![image](https://user-images.githubusercontent.com/63437430/151519656-75aec000-7b44-4e0c-842f-b7b0f58944d0.png)

Red
![image](https://user-images.githubusercontent.com/63437430/151519671-da6f28c3-63f8-43bd-a578-e26ec428a551.png)

Nutella
![image](https://user-images.githubusercontent.com/63437430/151519703-2074e2bb-9509-4ef6-b1ec-d6d9bfe48165.png)
